### PR TITLE
docs: fix Python 3 compatibility and document wkhtmltopdf dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ or Clone the repository and run
 
 ```python setup.py install```
 
+### Prerequisites
+
+`pdf_text_overlay` uses [pdfkit](https://pypi.org/project/pdfkit/) to generate PDFs from HTML templates. `pdfkit` is a wrapper and does not render PDFs itself — it requires the external [wkhtmltopdf](https://wkhtmltopdf.org/) binary to be installed separately and available on your system `PATH`.
+
+Install `wkhtmltopdf` for your platform:
+
+* **Linux (Debian/Ubuntu)**
+
+  ```sh
+  sudo apt-get install wkhtmltopdf
+  ```
+
+* **macOS (Homebrew)**
+
+  ```sh
+  brew install --cask wkhtmltopdf
+  ```
+
+* **Windows**
+
+  Download and run the installer from the [wkhtmltopdf downloads page](https://wkhtmltopdf.org/downloads.html), then add the installation directory (e.g. `C:\Program Files\wkhtmltopdf\bin`) to your system `PATH`.
+
+After installation, verify it's accessible by running `wkhtmltopdf --version` from a terminal. If the command is not found, double-check that the binary's location has been added to your `PATH`.
+
 ### Example: PDF text overlay
 
 ```python
@@ -85,16 +109,16 @@ data = json.loads("""{
    "bank_name":"HDFC BANK"
 }""")
 
-original_pdf = file("file_name.pdf", "rb")
-font = file("font_name.ttf", "rb")
+original_pdf = open("file_name.pdf", "rb")
+font = open("font_name.ttf", "rb")
 output = pdf_writer(original_pdf, configuration, data, font)
-outputStream = file("output.pdf", "wb")
+outputStream = open("output.pdf", "wb")
 output.write(outputStream)
 outputStream.close()
 ```
 
 ### Example: PDF from template
-```
+```python
 from pdf_text_overlay import pdf_from_template
 
 jinja_data = {


### PR DESCRIPTION

## Summary
- Replace deprecated Python 2 `file()` calls with `open()` in the PDF text overlay example so the README no longer produces a `NameError` on Python 3
- Add a "Prerequisites" section under Installation documenting that `pdfkit` requires the external `wkhtmltopdf` binary, with install instructions for Linux, macOS, and Windows and a note that it must be on the system `PATH`
- Add a `python` language hint to the "PDF from template" code block so it renders with syntax highlighting

Fixes #28

## Test plan
- [x] Verified no remaining `file()` usage in README
- [x] Verified both code blocks are Python 3 compatible and fenced with `python` for Markdown rendering
- Documentation-only change; no source files modified