### PR TITLE
fix: propagate font_size and validate font input in pdf_writer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,30 @@ or Clone the repository and run
 
 ```python setup.py install```
 
+### Prerequisites
+
+`pdf_text_overlay` uses [pdfkit](https://pypi.org/project/pdfkit/) to generate PDFs from HTML templates. `pdfkit` is a wrapper and does not render PDFs itself — it requires the external [wkhtmltopdf](https://wkhtmltopdf.org/) binary to be installed separately and available on your system `PATH`.
+
+Install `wkhtmltopdf` for your platform:
+
+* **Linux (Debian/Ubuntu)**
+
+  ```sh
+  sudo apt-get install wkhtmltopdf
+  ```
+
+* **macOS (Homebrew)**
+
+  ```sh
+  brew install --cask wkhtmltopdf
+  ```
+
+* **Windows**
+
+  Download and run the installer from the [wkhtmltopdf downloads page](https://wkhtmltopdf.org/downloads.html), then add the installation directory (e.g. `C:\Program Files\wkhtmltopdf\bin`) to your system `PATH`.
+
+After installation, verify it's accessible by running `wkhtmltopdf --version` from a terminal. If the command is not found, double-check that the binary's location has been added to your `PATH`.
+
 ### Example: PDF text overlay
 
 ```python
@@ -85,16 +109,16 @@ data = json.loads("""{
    "bank_name":"HDFC BANK"
 }""")
 
-original_pdf = file("file_name.pdf", "rb")
-font = file("font_name.ttf", "rb")
+original_pdf = open("file_name.pdf", "rb")
+font = open("font_name.ttf", "rb")
 output = pdf_writer(original_pdf, configuration, data, font)
-outputStream = file("output.pdf", "wb")
+outputStream = open("output.pdf", "wb")
 output.write(outputStream)
 outputStream.close()
 ```
 
 ### Example: PDF from template
-```
+```python
 from pdf_text_overlay import pdf_from_template
 
 jinja_data = {

--- a/README.md
+++ b/README.md
@@ -111,11 +111,16 @@ data = json.loads("""{
 
 original_pdf = open("file_name.pdf", "rb")
 font = open("font_name.ttf", "rb")
-output = pdf_writer(original_pdf, configuration, data, font)
+output = pdf_writer(original_pdf, configuration, data, font, font_size=10)
 outputStream = open("output.pdf", "wb")
 output.write(outputStream)
 outputStream.close()
 ```
+
+`pdf_writer(original_pdf, configuration, data, font, font_size=10)` parameters:
+
+* `font` (required) - either a path (`str`) to a `.ttf` file, or a file-like object opened in binary mode, e.g. `open("font.ttf", "rb")`. Passing `None` or an invalid path/type raises `InvalidFontError` with a clear message instead of an obscure ReportLab error.
+* `font_size` (optional, default `10`) - the default font size used to draw text. It can be overridden per field by setting `"font_size"` on that field's entry in `configuration` (see the `"name"` field above).
 
 ### Example: PDF from template
 ```python

--- a/pdf_text_overlay/__init__.py
+++ b/pdf_text_overlay/__init__.py
@@ -9,7 +9,17 @@ __author__ = 'Shridhar Patil'
 __email__ = 'shridharpatil2792@gmail.com'
 __version__ = '0.4.2'
 
-from .pdfWriter import pdf_writer, pdf_from_template, ConditionalCoordinatesNotFound # noqa
+from .pdfWriter import ( # noqa
+    pdf_writer,
+    pdf_from_template,
+    ConditionalCoordinatesNotFound,
+    InvalidFontError,
+)
 
 
-__all__ = ["pdf_writer", "pdf_from_template", "ConditionalCoordinatesNotFound"]
+__all__ = [
+    "pdf_writer",
+    "pdf_from_template",
+    "ConditionalCoordinatesNotFound",
+    "InvalidFontError",
+]

--- a/pdf_text_overlay/pdfWriter.py
+++ b/pdf_text_overlay/pdfWriter.py
@@ -7,6 +7,7 @@
     :copyright: (c) 2018 by Zerodha Technology.
     :license: see LICENSE for details.
 """
+import os
 from io import BytesIO
 
 from PyPDF2 import PdfReader
@@ -14,7 +15,7 @@ from PyPDF2 import PdfWriter
 
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfbase.ttfonts import TTFont, TTFError
 from reportlab.pdfgen import canvas
 
 import pdfkit
@@ -24,6 +25,46 @@ from jinja2 import Template
 class ConditionalCoordinatesNotFound(Exception):
     """Unable to conditional coordinates"""
     pass
+
+
+class InvalidFontError(Exception):
+    """Raised when the supplied font cannot be used to render the PDF."""
+    pass
+
+
+def _load_font(font):
+    """Validate ``font`` and load it as a reportlab TTFont.
+
+    :param font: path (str/bytes/os.PathLike) to a ``.ttf`` file, or a
+        file-like object opened in binary mode (e.g. ``open(path, "rb")``).
+    :raises InvalidFontError: if ``font`` is missing, of an unsupported
+        type, or cannot be parsed as a TrueType font.
+    """
+    if font is None:
+        raise InvalidFontError(
+            "font is required: pass a path to a .ttf file, or a "
+            "file-like object opened in binary mode "
+            "(e.g. open('font.ttf', 'rb'))"
+        )
+
+    is_file_like = hasattr(font, "read")
+    is_path = isinstance(font, (str, bytes, os.PathLike))
+
+    if not is_file_like and not is_path:
+        raise InvalidFontError(
+            "font must be a path to a .ttf file or a file-like object "
+            "opened in binary mode, got {!r}".format(type(font).__name__)
+        )
+
+    if is_path and not os.path.isfile(font):
+        raise InvalidFontError("Font file not found: {!r}".format(font))
+
+    try:
+        return TTFont('font_style', font)
+    except TTFError as e:
+        raise InvalidFontError(
+            "Could not load font {!r}: {}".format(font, e)
+        )
 
 
 class WriteToPDF(object):
@@ -37,14 +78,17 @@ class WriteToPDF(object):
         :param original_pdf (file obj): original pdf file object
         :param configuration (dict): configuration dict
         :param values (dict): values to be printed
-        :param font (file obj): font
+        :param font: path to a .ttf file, or a file-like object opened in
+            binary mode (e.g. open("font.ttf", "rb"))
+        :param font_size (int): default font size used for text drawn
+            without a per-field "font_size" in their configuration
         """
         self.original_pdf = original_pdf
         self.configuration = configuration
         self.values = values
         self.font_size = font_size
 
-        pdfmetrics.registerFont(TTFont('font_style', font))
+        pdfmetrics.registerFont(_load_font(font))
 
     def create_new_pdf(self, configuration):
         """Create a PDF with reportlab with given configuration
@@ -198,9 +242,12 @@ def pdf_writer(original_pdf, configuration, data, font, font_size=10):
     :param original_pdf (file obj): original pdf file object
     :param configuration (dict): configuration dict
     :param values (dict): values to be printed
-    :param font (file obj): font
+    :param font: path to a .ttf file, or a file-like object opened in
+        binary mode (e.g. open("font.ttf", "rb"))
+    :param font_size (int): default font size used for text drawn without
+        a per-field "font_size" in their configuration
     """
-    x = WriteToPDF(original_pdf, configuration, data, font)
+    x = WriteToPDF(original_pdf, configuration, data, font, font_size)
     output = x.edit_and_save_pdf()
     return output
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,18 @@ def fp(rel_path):
 
 
 @pytest.fixture
-def pdf_writer_inst():
+def font_path():
+    return fp("../examples/Lato-Italic.ttf")
+
+
+@pytest.fixture
+def blank_pdf():
+    with open(fp("./blank.pdf"), "rb") as f:
+        yield f
+
+
+@pytest.fixture
+def pdf_writer_inst(font_path):
     configuration, = json.loads(open(fp("./configuration.json")).read()),
     data = {}
     for config in configuration:
@@ -37,5 +48,5 @@ def pdf_writer_inst():
         original_pdf=open(fp("./blank.pdf"), "rb"),
         configuration=configuration,
         values=data,
-        font=open(fp("../examples/Lato-Italic.ttf"), "rb")
+        font=open(font_path, "rb")
     )

--- a/tests/test_pdfwriter.py
+++ b/tests/test_pdfwriter.py
@@ -10,10 +10,12 @@
 import pytest
 from mock import patch
 
-from pdf_text_overlay import ConditionalCoordinatesNotFound
+from pdf_text_overlay import ConditionalCoordinatesNotFound, InvalidFontError
+from pdf_text_overlay.pdfWriter import WriteToPDF, pdf_writer
 from reportlab.lib.utils import ImageReader
-from PyPDF2 import PdfFileWriter
-from PyPDF2.pdf import PageObject
+from reportlab.pdfgen import canvas
+from PyPDF2 import PdfWriter
+from PyPDF2._page import PageObject
 
 
 class TestWriteToPDF:
@@ -89,11 +91,96 @@ class TestWriteToPDF:
         pdf = pdf_writer_inst.create_new_pdf(configuration)
         assert pdf is not None
 
-    @patch.object(PageObject, "mergePage")
-    @patch.object(PdfFileWriter, "addPage")
-    def test_edit_and_save_pdf(self, mock_merge, mock_add, pdf_writer_inst):
+    @patch.object(PageObject, "merge_page")
+    @patch.object(PdfWriter, "add_page")
+    def test_edit_and_save_pdf(self, mock_add, mock_merge, pdf_writer_inst):
         pdf_writer_inst.values['gender'] = 'Male'
         output = pdf_writer_inst.edit_and_save_pdf()
         assert output is not None
         assert mock_merge.call_count == 3
         assert mock_add.call_count == 3
+
+    def test_custom_font_size_is_applied(self, pdf_writer_inst):
+        """font_size should be forwarded to the underlying canvas font."""
+        pdf_writer_inst.font_size = 24
+        pdf_writer_inst.values['gender'] = 'Male'
+        configuration = pdf_writer_inst.configuration[0]['variables']
+
+        with patch.object(canvas.Canvas, "setFont") as mock_set_font:
+            pdf_writer_inst.create_new_pdf(configuration)
+
+        mock_set_font.assert_any_call('font_style', 24)
+
+    def test_default_font_size_is_ten(self, pdf_writer_inst):
+        assert pdf_writer_inst.font_size == 10
+
+
+class TestFontValidation:
+
+    def test_missing_font_raises_invalid_font_error(self, blank_pdf):
+        with pytest.raises(InvalidFontError):
+            WriteToPDF(
+                original_pdf=blank_pdf,
+                configuration=[],
+                values={},
+                font=None,
+            )
+
+    def test_wrong_type_font_raises_invalid_font_error(self, blank_pdf):
+        with pytest.raises(InvalidFontError):
+            WriteToPDF(
+                original_pdf=blank_pdf,
+                configuration=[],
+                values={},
+                font=12345,
+            )
+
+    def test_nonexistent_font_path_raises_invalid_font_error(self, blank_pdf):
+        with pytest.raises(InvalidFontError):
+            WriteToPDF(
+                original_pdf=blank_pdf,
+                configuration=[],
+                values={},
+                font="/no/such/font.ttf",
+            )
+
+    def test_font_file_object_is_accepted(self, blank_pdf, font_path):
+        with open(font_path, "rb") as font_file:
+            inst = WriteToPDF(
+                original_pdf=blank_pdf,
+                configuration=[],
+                values={},
+                font=font_file,
+            )
+        assert inst is not None
+
+    def test_font_path_string_is_accepted(self, blank_pdf, font_path):
+        inst = WriteToPDF(
+            original_pdf=blank_pdf,
+            configuration=[],
+            values={},
+            font=font_path,
+        )
+        assert inst is not None
+
+
+class TestPdfWriter:
+
+    @patch("pdf_text_overlay.pdfWriter.WriteToPDF")
+    def test_forwards_font_and_font_size(self, mock_write_to_pdf):
+        mock_instance = mock_write_to_pdf.return_value
+
+        pdf_writer("original_pdf", [], {}, "font", font_size=24)
+
+        mock_write_to_pdf.assert_called_once_with(
+            "original_pdf", [], {}, "font", 24
+        )
+        mock_instance.edit_and_save_pdf.assert_called_once()
+
+    @patch("pdf_text_overlay.pdfWriter.WriteToPDF")
+    def test_default_font_size_forwarded(self, mock_write_to_pdf):
+        pdf_writer("original_pdf", [], {}, "font")
+
+        mock_write_to_pdf.assert_called_once_with(
+            "original_pdf", [], {}, "font", 10
+        )


### PR DESCRIPTION
## Summary
- `pdf_writer()` accepted a `font_size` argument but never forwarded it to `WriteToPDF`, so it silently had no effect on rendered output. It's now passed through correctly.
- Added `InvalidFontError` with clear messages for missing, wrong-type, or nonexistent `font` input, instead of obscure ReportLab/TTFError tracebacks. Both a file path (`str`/`bytes`/`os.PathLike`) and a file-like object opened in binary mode are supported and documented (matches what ReportLab's `TTFont`/`TTFontParser` natively accept).
- Fixed `tests/test_pdfwriter.py`, which was broken at collection due to leftover PyPDF2 2.x API references (`PdfFileWriter`, `PageObject.mergePage`, `PyPDF2.pdf`) from an earlier PyPDF2 3.x migration — updated to `PdfWriter`/`PageObject.merge_page`.
- Added tests for default vs. custom `font_size`, `font` as path vs. file object, and invalid font inputs (`None`, wrong type, nonexistent path), plus a regression test pinning `pdf_writer()`'s forwarding of `font`/`font_size` into `WriteToPDF`.
- Documented the `font`/`font_size` parameter contract in the README.

Fixes #27

## Test plan
- [x] `python -m pytest tests/` — 12 passed
- [x] Confirmed new regression test fails against the original (unfixed) `pdf_writer()` and passes after the fix
- [x] End-to-end smoke test: `pdf_writer(original_pdf, configuration, data, font, font_size=18)` runs successfully outside of mocks

Note: branch font-fix and master are both already on origin — just open the PR from font-fix into master whenever you're ready.